### PR TITLE
Fixes to targets display

### DIFF
--- a/smicli/_click_common.py
+++ b/smicli/_click_common.py
@@ -373,7 +373,7 @@ def print_table(rows, headers=None, title=None, table_format='simple'):
         #                    tablefmt=table_format))
     else:
         if title:
-            print('\n\n%s\n' % title)
+            click.echo('\n\n%s\n' % title)
         click.echo(tabulate(rows, headers=headers, tablefmt=table_format))
 
 

--- a/smipyping/_targetstable.py
+++ b/smipyping/_targetstable.py
@@ -63,7 +63,7 @@ class TargetsTable(DBTableBase):
     key_field = 'TargetID'
     fields = [key_field, 'IPAddress', 'CompanyID', 'Namespace',
               'SMIVersion', 'Product', 'Principal', 'Credential',
-              'CimomVersion', 'InteropNamespace', 'Notify', 'NotifyUsers',
+              'CimomVersion', 'InteropNamespace', 'NotifyUsers',
               'ScanEnabled', 'Protocol', 'Port']
     table_name = 'Targets'
 
@@ -498,6 +498,9 @@ class MySQLTargetsTable(SQLTargetsTable):
         except Exception as ex:
             raise ValueError('Error: putting Company Name in table %r error %s'
                              % (self.db_dict, ex))
+
+        for target in self.data_dict:
+            print('TARGET %s' % self.data_dict[target])
 
     def update_fields(self, target_id, changes):
         """


### PR DESCRIPTION
1. The change to a add order caused a problem in that it only displayed
one of the possible multiple entries selected for order.  Thus if
CompanyName was the order, only one company would be displayed.

2. Added the -f option to targets list fields and order options