### PR TITLE
Add doc on cimping exception codes  and remove prints

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -7,6 +7,43 @@ Appendix
 This section contains information that is referenced from other sections,
 and that does not really need to be read in sequence.
 
+.. _'WBEM server error codes`:
+
+WBEM server error codes
+-----------------------
+
+when tests like `smicli cimping` are executed, smicli collects any errors
+returned from the servers. If the tests requests that the data update the
+database, (-s option) these error  codes are set into the entries of the
+history database.
+
+The possible errors are:
+
+1. OK - Server response good, no error.
+
+2. WBEMError(1) - WBEM Server returned a DMTF define CIMError code.
+
+3. PyWBEMError(2) - pywbem generated an exception for the request. Since
+   pywbem generates a number of different error exceptions (XML errors, etc)
+   the specific error text is included with this error
+
+4. GeneralError(3) - pywbem generated a general error (obsolete)
+
+5. TimeoutError(4) - pywbem generated a timeout error waiting for the
+   request response.  The timeout is defined as part of the connection
+   setup and most in smicli defaults to 10 seconds
+
+6. ConnectionError(5) - pywbem generated a connection exception, typically
+   this is a failure to connect to the server or an ssl error.
+
+7. PingFail(6) - If smicli was requested to do a ping (os level ping program)
+   and that failed, this error is generated. It means that the ping of the
+   ip address failed and usually means that the defined server does not exist.
+
+8. Disabled(7) - If the command options specified that disable target servers
+   be included, those servers are marked with this error code.
+
+
 
 .. _'Special type names`:
 
@@ -65,48 +102,7 @@ This documentation uses a few special terms to refer to Python types:
 Troubleshooting
 ---------------
 
-Here are some trouble shooting hints for the installation of pywbem.
-
-AttributeError for NullHandler during mkvirtualenv on Python 2.6
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If the `mkvirtualenv` command fails on Python 2.6 with this error::
-
-    File "/usr/lib/python2.6/site-packages/stevedore/__init__.py", line 23,
-      in <module> LOG.addHandler(logging.NullHandler())
-    AttributeError: 'module' object has no attribute 'NullHandler'
-
-then the `stevedore` PyPI package is too recent(!) The owners of that
-package spent effort to remove the previously existing Python 2.6 support in
-some steps, starting with stevedore v1.10.
-
-The solution is to use stevedore v1.9. Note that for virtualenvwrapper to use
-it, it must be installed into the system Python:
-
-    $ sudo pip install stevedore==1.9
-
-TypeError about StreamHandler argument 'stream' during mkvirtualenv on Python 2.6
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If the `mkvirtualenv` command fails on Python 2.6 with this error::
-
-    File "/usr/lib/python2.6/site-packages/virtualenvwrapper/hook_loader.py",
-      line 101, in main
-    console = logging.StreamHandler(stream=sys.stderr)
-    TypeError: __init__() got an unexpected keyword argument 'stream'
-
-then the `virtualenvwrapper` PyPI package is too old. As of its released
-version v4.7.1, a fix for that is in the master branch of its repository and
-has not been released yet.
-
-While a new version of `virtualenvwrapper` with the fix is not yet released,
-a solution is to clone the `virtualenvwrapper` repository and to install it
-from its working directory. Note that it must be installed into the system
-Python::
-
-    $ git clone https://bitbucket.org/dhellmann/virtualenvwrapper.git virtualenvwrapper
-    $ cd virtualenvwrapper
-    $ sudo python setup.py install
+Here are some trouble shooting hints for the installation of smipyping and pywbem.
 
 Swig error 'Unrecognized option -builtin' during M2Crypto install
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,7 +158,7 @@ Glossary
       cycle cannot be managed by a client.
       See :term:`DSP1054` for an authoritative definition and for details.
 
-   
+
 .. _`References`:
 
 References

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -95,6 +95,8 @@ save history.
 Database schema
 ---------------
 
+The database schema defines the various tables in the database.
+
 MySQL Database
 ^^^^^^^^^^^^^^
 

--- a/docs/smiclicmdshelp.rst
+++ b/docs/smiclicmdshelp.rst
@@ -142,18 +142,28 @@ The following defines the help output for the `smicli cimping all --help` subcom
       ex. smicli cimping all
 
     Options:
-      -t, --timeout INTEGER  Timeout in sec for the operation. (Default: 10).
-      --no-ping              Disable network ping of the wbem server before
-                             executing the cim request. (Default: True).
       -s, --saveresult       Save the result of each cimping test of a wbem server
                              to the database Pings table for future analysis.
                              Saving the results creates an audit log record.
                              (Default: False).
       -d, --disabled         If set include disabled targets in the cimping scan.
                              (Default: False).
-      -d, --debug            Set the debug parameter for the pywbem call. Displays
-                             detailed information on the call and response.
-                             (Default: False).
+      -t, --timeout INTEGER  Timeout in sec for the pywbem operations to test the
+                             server. (Default: 10).
+      --no-ping              If set this option disables network level ping of the
+                             wbem server before executing the cim request. Since
+                             executing the ping does not cause significant time
+                             delay and helps define servers that are not
+                             respondingat all, normally it should not be set. The
+                             ping uses available ping program to execute the ping.
+      -d, --debug            If set this options sets the debug parameter for the
+                             pywbem call. Displays detailed information on the
+                             call and response.
+      --no-thread            If set run test single-threaded if no-thread set.
+                             This option exists to aid debugging if issues occur
+                             with multithreading or the servers responses in
+                             general. If not set, the requests to each server are
+                             issued in parallel using multi-threading.
       -h, --help             Show this message and exit.
 
 
@@ -260,13 +270,25 @@ The following defines the help output for the `smicli cimping id --help` subcomm
       ex. smicli cimping 5
 
     Options:
-      -t, --timeout INTEGER  Timeout in sec for the operation. (Default: 10).
+      -t, --timeout INTEGER  Timeout in sec for the pywbem operations to test the
+                             server. (Default: 10).
       -i, --interactive      If set, presents list of targets to chose.
-      --no-ping              Disable network ping of the wbem server before
-                             executing the cim request. (Default: True).
-      -d, --debug            Set the debug parameter for the pywbem call. Displays
-                             detailed information on the call and response.
-                             (Default: False).
+      --no-ping              If set this option disables network level ping of the
+                             wbem server before executing the cim request. Since
+                             executing the ping does not cause significant time
+                             delay and helps define servers that are not
+                             respondingat all, normally it should not be set. The
+                             ping uses available ping program to execute the ping.
+      -d, --debug            If set this options sets the debug parameter for the
+                             pywbem call. Displays detailed information on the
+                             call and response.
+      --no-thread            If set run test single-threaded if no-thread set.
+                             This option exists to aid debugging if issues occur
+                             with multithreading or the servers responses in
+                             general. If not set, the requests to each server are
+                             issued in parallel using multi-threading.
+      -t, --timeout INTEGER  Timeout in sec for the pywbem operations to test the
+                             server. (Default: 10).
       -h, --help             Show this message and exit.
 
 
@@ -293,13 +315,18 @@ The following defines the help output for the `smicli cimping ids --help` subcom
       ex. smicli cimping ids 5 8 9
 
     Options:
-      -t, --timeout INTEGER  Timeout in sec for the operation. (Default: 10).
-      --no-ping              Disable network ping of the wbem server before
-                             executing the cim request. (Default: True).
+      -t, --timeout INTEGER  Timeout in sec for the pywbem operations to test the
+                             server. (Default: 10).
+      --no-ping              If set this option disables network level ping of the
+                             wbem server before executing the cim request. Since
+                             executing the ping does not cause significant time
+                             delay and helps define servers that are not
+                             respondingat all, normally it should not be set. The
+                             ping uses available ping program to execute the ping.
       -i, --interactive      If set, presents list of targets to chose.
-      -d, --debug            Set the debug parameter for the pywbem call. Displays
-                             detailed information on the call and response.
-                             (Default: False).
+      -d, --debug            If set this options sets the debug parameter for the
+                             pywbem call. Displays detailed information on the
+                             call and response.
       -h, --help             Show this message and exit.
 
 
@@ -525,8 +552,9 @@ The following defines the help output for the `smicli explorer all --help` subco
     Options:
       --ping / --no-ping             Ping the the provider as initial step in
                                      test. Default: ping
-      --thread / --no-thread         Run test multithreaded.  Much faster.
-                                     Default: thread
+      --thread / --no-thread         Run test multithreaded.  Much faster. This
+                                     option is onlyhere to aid debugging if issues
+                                     occur with multithread.Default: thread
       -i, --include-disabled         Include hosts marked disabled in the targets
                                      table.
       -d, --detail [full|brief|all]  Generate full or brief (fewer columns)
@@ -619,17 +647,19 @@ The following defines the help output for the `smicli history --help` subcommand
       Rather than a simple list subcommand this subcommand includes a number of
       reports to view the table for:
 
-        - changes to status for particular targets.   - Consolidated history
-        over time periods   - Snapshots of the full set of entries over periods
-        of time.
+        - changes to status for particular targets.
+
+        - Consolidated history over time periods
+
+        - Snapshots of the full set of entries over periods of time.
 
     Options:
       -h, --help  Show this message and exit.
 
     Commands:
-      delete    Delete records from history file.
-      list      List history of pings in database.
-      overview  Get overview of pings in database.
+      delete    Delete records from pings table.
+      list      Display history of pings in database.
+      overview  Display overview of pingstable in database.
       timeline  Show history of status changes for IDs.
       weekly    Generate weekly report from ping history.
 
@@ -648,10 +678,10 @@ The following defines the help output for the `smicli history delete --help` sub
 
     Usage: smicli history delete [COMMAND-OPTIONS]
 
-      Delete records from history file.
+      Delete records from pings table.
 
-      Delete records from the history file based on start date and end date
-      options and the optional list of target ids provided.
+      Delete records from the history(pings) database based on start date and
+      end date options and the optional list of targetids provided.
 
       ex. smicli history delete --startdate 09/09/17 --endate 09/10/17
 
@@ -690,24 +720,39 @@ The following defines the help output for the `smicli history list --help` subco
 
     Usage: smicli history list [COMMAND-OPTIONS]
 
-      List history of pings in database.
+      Display history of pings in database.
+
+      It outputs a table data from the database pings table which may be
+      filtered by targets and dates.
 
       The listing may be filtered a date range with the --startdate, --enddate,
-      and --numberofdays options.  It may also be filtered to only show a single
-      target WBEM server from the targets table with the `--targetid` option
+      and --numberofdays options.
+
+      It may also be filtered to only show a selected target WBEM server from
+      the targets table with the `--targetid` option
 
       The output of this subcommand is determined by the `--result` option which
       provides for:
 
-        * `full` - all records defined by the input parameters
+        * `full` - all records defined by the input parameters.
 
         * `status` - listing records by status (i.e. OK, etc.) and     count of
-        records for that status
+        records for that status.
 
         * `%ok` - listing the percentage of records that have 'OK' status and
-        the total number of ping records
+        the total number of ping records.
 
-        * `count` - count of records within the defined date/time range
+        * `count` - count of records within the defined date/time range.
+
+      ex. smicli history list --startdate 09/09/17 --enddate 09/10/17
+
+          smicli history list --startdate 09/09/17 --numberofdays 9 -t 88 -t 91
+
+          smicli history list --startdate 09/09/17 --numberofdays 9 - *
+
+              # list pings for 9 days starting 9 sept 17 for targets
+
+              # selected by user (-t *)
 
     Options:
       -t, --targetIds TEXT            Get results only for the defined targetIDs.
@@ -751,7 +796,7 @@ The following defines the help output for the `smicli history overview --help` s
 
     Usage: smicli history overview [COMMAND-OPTIONS]
 
-      Get overview of pings in database.
+      Display overview of pingstable in database.
 
       This subcommand only shows the count of records and the oldest and newest
       record in the pings database, and the number of pings by program.
@@ -783,26 +828,22 @@ The following defines the help output for the `smicli history timeline --help` s
       Each line in the report is a status change.
 
     Options:
-      -t, --targetids TEXT            Get results only for the defined targetIDs.
-                                      If the value is "?" a select list is
-                                      provided to the console to select the  WBEM
-                                      server targetids from the targets table.
-      -s, --startdate DATE            Start date for ping records included. Format
-                                      is dd/mm/yy where dd and mm are zero padded
-                                      (ex. 01) and year is without century (ex.
-                                      17). Default: is oldest record
-      -e, --enddate DATE              End date for ping records included. Format
-                                      is dd/mm/yy where dd and dm are zero padded
-                                      (ex. 01) and year is without century (ex.
-                                      17). Default: is current datetime
-      -n, --numberofdays INTEGER      Alternative to enddate. Number of days to
-                                      report from startdate. "enddate" ignored if
-                                      "numberofdays" set
-      -r, --result [full|status|%ok]  "full" displays all records, "status"
-                                      displays status summary by id. "%ok" reports
-                                      percentage pings OK by Id and total count.
-                                      Default="status".
-      -h, --help                      Show this message and exit.
+      -t, --targetIds TEXT        Get results only for the defined targetIDs. If
+                                  the value is "?" a select list is provided to
+                                  the console to select the  WBEM server targetids
+                                  from the targets table.
+      -s, --startdate DATE        Start date for ping records included. Format is
+                                  dd/mm/yy where dd and mm are zero padded (ex.
+                                  01) and year is without century (ex. 17).
+                                  Default:oldest record
+      -e, --enddate DATE          End date for ping records included. Format is
+                                  dd/mm/yy where dd and dm are zero padded (ex.
+                                  01) and year is without century (ex. 17).
+                                  Default:current datetime
+      -n, --numberofdays INTEGER  Alternative to enddate. Number of days to report
+                                  from startdate. "enddate" ignored if
+                                  "numberofdays" set
+      -h, --help                  Show this message and exit.
 
 
 .. _`smicli history weekly --help`:
@@ -821,6 +862,8 @@ The following defines the help output for the `smicli history weekly --help` sub
 
       Generate weekly report from ping history.
 
+      Generates the report normally emailed for the smi lab status.
+
       This subcommand generates a report on the status of each target id in the
       targets table filtered by the --date parameter. It generates a summary of
       the status for the current day, for the previous week and for the total
@@ -833,6 +876,8 @@ The following defines the help output for the `smicli history weekly --help` sub
       This report includes percentage OK for each target for today, this week,
       and the program and overall information on the target (company, product,
       SMIversion, contacts.)
+
+      The error codes are documented in the online documentation.
 
     Options:
       -d, --date DATE   Optional date to be used as basis for report in form
@@ -1695,7 +1740,7 @@ The following defines the help output for the `smicli targets modify --help` sub
                                       namespace.
       --cimonversion TEXT             Modify the cimomversion field with a new
                                       namespace.
-      --companyid INTEGER             Modify the companyID field with the correct
+      --companyid TEXT                Modify the companyID field with the correct
                                       ID from the Company Table. Entering "?" into
                                       this field enables the interactive display
                                       of companies for selection of the company id

--- a/docs/smiclisubcommands.rst
+++ b/docs/smiclisubcommands.rst
@@ -54,20 +54,25 @@ information and execute the repl mode.
 
 The command groups available for smicli are:
 
-1. **cimping:**  -  Command group to do simpleping on providers to determine general
-   status of the provider.  This command group executes an optional ping and
-   if that is successful a single request for a now entity on the WBEM Server
-   to determine status. Generally it establishes that the smicli can
-   connect to the server and that the expected namespace and class exist.
+1. **cimping:** - Command group to do simpleping on providers to determine general
+   status of the provider.  This command group executes an optional ping using
+   the OS level ping and if that is successful a single request for a known
+   entity (ex. CIMClass) on the WBEM Server to determine status. Generally it
+   establishes that the smicli can connect to the server and that the expected
+   namespace and class exist.
 
-2. **explorer:** -  Command group to explore providers. This group provides commands
+   This command returns a number of possible errors for exception  responses
+   indicating the type of error received. See WBEM server
+   :ref:`WBEM server error codes` for details of the error codes.
+
+2. **explorer:** - Command group to explore providers. This group provides commands
    to explore status and state of providers including profiles, namespaces,
    general size of tables, etc.
 
-3. **provider:** -  Command group for detailed provider operations. This allows
+3. **provider:** - Command group for detailed provider operations. This allows
    users to explore providers (targets) in detail.
 
-4. **sweep:** -     Command group to sweep for servers. Allows testing all
+4. **sweep:** - Command group to sweep for servers. Allows testing all
    addresses in a range of ip address for possible WBEM Servers and determining
    if these are already in the targets table. Typically a search would be
    executed for all IP addresses in a known subnet and for selected ports.
@@ -80,16 +85,17 @@ The command groups available for smicli are:
    Credentials (taken from the target table) and possible namespaces to
    determine if a WBEM Server exists and reports what it finds.
 
-5. **history:** -   Command group to manage the history (pings) table. This includes
+5. **history:** - Command group to manage the history (pings) table. This includes
    a number of reports to summarize history of individual and all provider
-   status over time periods.
+   status over time periods. It also include a subcommand specifically to
+   execute the smilab weekly report `smicli history weekly`.
 
-6. **programs:**   Command group to view and manage the
+6. **programs:** - Command group to view and manage the
    programs table. This table is the definition of a single SMI program and
    defines the program name, start date and end date.
    Provides the capability to list and modify entries.
 
-6. **targets:** -   Command group for managing targets data.  This is the table of
+6. **targets:** - Command group for managing targets data.  This is the table of
    providers currently defined and includes information on the address, security,
    etc on each entry.  Normally it includes information that cannot be
    retrievied from the providers themselves.  This subcommand allows listing
@@ -101,7 +107,7 @@ The command groups available for smicli are:
    in these tables can be linked to a company
    This group provides viewing and managing entries in the table.
 
-8. **users:**  - Command group to process the users table. The users table
+8. **users:** - Command group to process the users table. The users table
    defines users associated with a company including email addresses so that
    notifications, reports, etc. can be forwarded to users concerning status
    and status changes of the targets. This group provides

--- a/smicli/_cmd_cimping.py
+++ b/smicli/_cmd_cimping.py
@@ -300,8 +300,6 @@ def cmd_cimping_all(context, options):  # pylint: disable=redefined-builtin
     # cimping the complete set of targets
     include_disabled = options['disabled']
 
-    print('Start ping options %s' % options)
-
     simple_ping_list = SimplePingList(context.targets_tbl,
                                       timeout=options['timeout'],
                                       logfile=context.log_file,
@@ -311,8 +309,6 @@ def cmd_cimping_all(context, options):  # pylint: disable=redefined-builtin
                                       include_disabled=include_disabled)
     results = simple_ping_list.ping_servers()
 
-    print('ping test ended')
-
     # get last pings information from history
     pings_tbl = PingsTable.factory(context.db_info, context.db_type,
                                    context.verbose)
@@ -320,8 +316,6 @@ def cmd_cimping_all(context, options):  # pylint: disable=redefined-builtin
     ping_rows = pings_tbl.get_last_timestamped()
     last_status = {ping[1]: ping[3] for ping in ping_rows}
     last_status_time = ping_rows[0][2]
-
-    print("got results from history")
 
     # if saveresult set, update pings table with results.
     save_result = options['saveresult']

--- a/smicli/_cmd_history.py
+++ b/smicli/_cmd_history.py
@@ -262,6 +262,8 @@ def history_weekly(context, **options):  # pylint: disable=redefined-builtin
     """
     Generate weekly report from ping history.
 
+    Generates the report normally emailed for the smi lab status.
+
     This subcommand generates a report on the status of each target id
     in the targets table filtered by the --date parameter. It generates
     a summary of the status for the current day, for the previous week and
@@ -271,11 +273,11 @@ def history_weekly(context, **options):  # pylint: disable=redefined-builtin
     ending at the time the report is generated but the --date pararameter
     allows the report to be generated for previous dates.
 
+    This report includes percentage OK for each target for today, this week,
+    and the program and overall information on the target (company, product,
+    SMIversion, contacts.)
 
-    This report includes percentage OK for each
-    target for today, this week, and the program and overall information on
-    the target (company, product, SMIversion, contacts.)
-
+    The error codes are documented in the online documentation.
     """
     context.execute_cmd(lambda: cmd_history_weekly(context, options))
 
@@ -431,15 +433,20 @@ def cmd_history_weekly(context, options):
 
     context.spinner.stop()
 
+    report_info = "  PingFail(WBEMServer fails 'ping'), "  \
+                  "WBEMError(CIMError exception), "  \
+                  "PyWBEMError/ConnectionError/TimeOutError" \
+                  "(Pywbem exception generated)"
     print_table(tbl_rows, headers,
-                title=('Server Status: Report-date=%s '
+                title=('Server status: date=%s '
                        'program=%s start: %s end: '
-                       '%s, LastScan: %s' %
+                       '%s, LastScan: %s\n%s' %
                        (datetime_display_str(report_date),
                         cp['ProgramName'],
                         cp['StartDate'],
                         cp['EndDate'],
-                        last_status_time)),
+                        last_status_time,
+                        report_info)),
                 table_format=context.output_format)
 
 
@@ -508,7 +515,7 @@ def cmd_history_delete(context, options):
                                    (ex.__class__.__name__, ex))
 
 
-def cmd_history_overview(context, options):  # pylint: diable=unused-argument
+def cmd_history_overview(context, options):  # pylint: disable=unused-argument
     """
     Get overall information on the pings table.
     """

--- a/smipyping/_simpleping.py
+++ b/smipyping/_simpleping.py
@@ -161,8 +161,6 @@ class SimplePingList(object):
             KeyboardInterrupt:
 
         """
-        print("SELF %s" % self)
-
         if self.threaded:
             return self.ping_servers_threaded()
 


### PR DESCRIPTION
Removed a number of print statements

Added documentation on the exception codes to the docs and also a short
overview of the codes to the cimping help.